### PR TITLE
C++20 compatible changes

### DIFF
--- a/cmake/FloatTetwildDownloadExternal.cmake
+++ b/cmake/FloatTetwildDownloadExternal.cmake
@@ -75,16 +75,16 @@ endfunction()
 ## fmt
 function(float_tetwild_download_fmt)
     float_tetwild_download_project(fmt
-        URL      https://github.com/fmtlib/fmt/archive/5.3.0.tar.gz
-        URL_MD5  1015bf3ff2a140dfe03de50ee2469401
+        GIT_REPOSITORY https://github.com/fmtlib/fmt
+        GIT_TAG        40626af88bd7df9a5fb80be7b25ac85b122d6c21
     )
 endfunction()
 
 ## spdlog
 function(float_tetwild_download_spdlog)
     float_tetwild_download_project(spdlog
-        URL         https://github.com/gabime/spdlog/archive/v1.3.1.tar.gz
-        URL_MD5     3c17dd6983de2a66eca8b5a0b213d29f
+        GIT_REPOSITORY https://github.com/gabime/spdlog
+        GIT_TAG        6fa36017cfd5731d617e1a934f0e5ea9c4445b13
     )
 endfunction()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,8 @@ set(SOURCES
 	Types.hpp
 
 	Statistics.h
+
+	RandomSource.h
 )
 
 prepend_current_path(SOURCES)

--- a/src/RandomSource.h
+++ b/src/RandomSource.h
@@ -1,0 +1,14 @@
+// This file is part of fTetWild, a software for generating tetrahedral meshes.
+//
+// Copyright (C) 2019 Yixin Hu <yixin.hu@nyu.edu>
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+#ifndef FLOATTETWILD_RANDOMSOURCE_H
+#define FLOATTETWILD_RANDOMSOURCE_H
+
+std::random_device rd;
+
+#endif //FLOATTETWILD_RANDOMSOURCE_H

--- a/src/TriangleInsertion.cpp
+++ b/src/TriangleInsertion.cpp
@@ -21,6 +21,8 @@
 
 #include <floattetwild/MeshImprovement.h>//fortest
 
+#include <floattetwild/RandomSource.h> // for rd
+
 #include <igl/writeSTL.h>
 #include <igl/writeOFF.h>
 #include <igl/Timer.h>
@@ -34,6 +36,7 @@
 #include <tbb/concurrent_vector.h>
 #endif
 
+#include <algorithm>
 #include <bitset>
 #include <numeric>
 #include <unordered_map>
@@ -140,7 +143,9 @@ void floatTetWild::sort_input_faces(const std::vector<Vector3> &input_vertices, 
     if (mesh.params.not_sort_input)
         return;
 
-    std::random_shuffle(sorted_f_ids.begin(), sorted_f_ids.end());
+    std::mt19937 g(rd()); // Standard mersenne_twister_engine seeded with rd()
+
+    std::shuffle(sorted_f_ids.begin(), sorted_f_ids.end(), g);
 //    std::sort(sorted_f_ids.begin(), sorted_f_ids.end(), [&weights](int a, int b) {
 //        return weights[a] < weights[b];
 //    });


### PR DESCRIPTION
- Updated fmt to version [11.2.0](https://github.com/fmtlib/fmt/commit/40626af88bd7df9a5fb80be7b25ac85b122d6c21)

- spdlog had to be updated to match the updated fmt. spdlog was updated to version [1.15.2](https://github.com/gabime/spdlog/commit/48bcf39a661a13be22666ac64db8a7f886f2637e)

- Replaced the removed function `std::random_shuffle` by `std::shuffle` and providing a mersenne twister as the pseudo-number generator.


The mersenne twister has better statistical properties than the internal `std::rand` used in `std::random_shuffle` but perhaps, it may have unintended negative consequences. I'm not exactly sure about the impact of such a change.