### PR TITLE
direct ideal edge length setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ Options:
   -o,--output TEXT            Output tetmesh OUTPUT in .msh format. (string, optional, default: input_file+postfix+'.msh')
   --tag TEXT:FILE             Tag input faces for Boolean operation.
   --op INT                    Boolean operation: 0: union, 1: intersection, 2: difference.
-  -l,--lr FLOAT               ideal_edge_length = diag_of_bbox * L. (double, optional, default: 0.05)
+  -a,--la FLOAT               Ideal edge length not scaled by diag_of_bbox. Excludes: --lr. (double, optional)
+  -l,--lr FLOAT               ideal_edge_length = diag_of_bbox * L. Excludes: --la. (double, optional, default: 0.05)
   -e,--epsr FLOAT             epsilon = diag_of_bbox * EPS. (double, optional, default: 1e-3)
   --stop-energy FLOAT         Stop optimization when max energy is lower than this.
   --log TEXT                  Log info to given file.

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -62,6 +62,9 @@ namespace floatTetWild {
         Scalar ideal_edge_length_rel = 1 / 20.0;
         Scalar min_edge_len_rel = -1;
 
+        // initial absolute target edge length not scaled to the box diagonal
+        Scalar ideal_edge_length_abs = 0.0;
+
         int max_its = 80;
         Scalar stop_energy = 10;
 
@@ -104,7 +107,13 @@ namespace floatTetWild {
 
             bbox_diag_length = bbox_diag_l;
 
-            ideal_edge_length = bbox_diag_length * ideal_edge_length_rel;
+            if (ideal_edge_length_abs > 0.0) {
+                ideal_edge_length = ideal_edge_length_abs;
+                ideal_edge_length_rel = ideal_edge_length / bbox_diag_length;
+            }
+            else {
+                ideal_edge_length = bbox_diag_length * ideal_edge_length_rel;
+            }
             ideal_edge_length_2 = ideal_edge_length * ideal_edge_length;
 
             eps_input = bbox_diag_length * eps_rel;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -193,10 +193,16 @@ int main(int argc, char** argv)
     command_line.add_option(
       "--op", boolean_op, "Boolean operation: 0: union, 1: intersection, 2: difference.");
 
-    command_line.add_option(
+    auto absolute_op = command_line.add_option(
+      "-a,--la",
+      params.ideal_edge_length_abs,
+      "Ideal edge length not scaled by diag_of_bbox. (double, optional)");
+    auto relative_op = command_line.add_option(
       "-l,--lr",
       params.ideal_edge_length_rel,
       "ideal_edge_length = diag_of_bbox * L. (double, optional, default: 0.05)");
+    relative_op->excludes(absolute_op);
+
     command_line.add_option("-e,--epsr",
                             params.eps_rel,
                             "epsilon = diag_of_bbox * EPS. (double, optional, default: 1e-3)");


### PR DESCRIPTION
Allow users to specify the desired edge length directly instead of being dependent on the diagonal of the bounding box for convenience. 

This is akin to https://github.com/Yixin-Hu/TetWild/pull/63.

Fixes #87.