### PR TITLE
 Make GMP an optional dependency; add developer documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ option(FLOAT_TETWILD_ENABLE_TBB "Enable TBB" ON)
 option(FLOAT_TETWILD_USE_FLOAT "Use floats instead of double" OFF)
 option(FLOAT_TETWILD_WITH_SANITIZERS "Use sanitizers" OFF)
 option(FLOAT_TETWILD_WITH_EXACT_ENVELOPE "Use exact envelope" OFF)
+option(FLOAT_TETWILD_USE_GMP "Use GMP for exact rational arithmetic (AMIPS energy stabilisation). When OFF a long double fallback is used." OFF)
 
 # Sanitizer options
 option(SANITIZE_ADDRESS "Sanitize Address" OFF)
@@ -81,9 +82,14 @@ igl_include(predicates)
 # FloatTetwild library
 # ##############################################################################
 
-find_package(GMPfTetWild)
-if(NOT ${GMP_FOUND})
-    message(FATAL_ERROR "Cannot find GMP")
+if(FLOAT_TETWILD_USE_GMP)
+    find_package(GMPfTetWild)
+    if(NOT ${GMP_FOUND})
+        message(FATAL_ERROR "Cannot find GMP. Install libgmp-dev or disable with -DFLOAT_TETWILD_USE_GMP=OFF.")
+    endif()
+    message(STATUS "GMP enabled: using exact rational arithmetic for AMIPS energy stabilisation")
+else()
+    message(STATUS "GMP disabled: using long double fallback for AMIPS energy stabilisation")
 endif()
 
 # add_library() can only be called without any source since CMake 3.11 ...
@@ -117,7 +123,10 @@ if(FLOAT_TETWILD_USE_FLOAT)
     target_compile_definitions(${PROJECT_NAME} PUBLIC -DFLOAT_TETWILD_USE_FLOAT)
 endif()
 
-target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${GMP_INCLUDE_DIRS})
+if(FLOAT_TETWILD_USE_GMP)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC FLOAT_TETWILD_USE_GMP)
+    target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${GMP_INCLUDE_DIRS})
+endif()
 
 target_link_libraries(
   ${PROJECT_NAME}
@@ -126,11 +135,12 @@ target_link_libraries(
          geogram::geogram
          spdlog::spdlog
          Threads::Threads
-         # fast_winding_number
          json
-         ${GMP_LIBRARIES}
-         # ${MPFR_LIBRARIES}
 )
+
+if(FLOAT_TETWILD_USE_GMP)
+    target_link_libraries(${PROJECT_NAME} PUBLIC ${GMP_LIBRARIES})
+endif()
 if(FLOAT_TETWILD_ENABLE_TBB)
     target_link_libraries(${PROJECT_NAME} PUBLIC TBB::tbb)
     target_compile_definitions(${PROJECT_NAME} PUBLIC FLOAT_TETWILD_USE_TBB)

--- a/README.md
+++ b/README.md
@@ -50,9 +50,20 @@ Here is pre-generated tetmeshes and the extracted surface meshes for research-pu
 
 - Figures in the paper: [Input/output & scripts](https://drive.google.com/file/d/1qTukYF3N05jLxKxYQK5tNOUdFAr_0sf1/view?usp=sharing)
 
+## Documentation
+
+Full documentation is available in the [`doc/`](doc/index.md) folder:
+
+- [Algorithm overview](doc/overview.md)
+- [Dependencies](doc/dependencies.md)
+- [Library API](doc/library_api.md)
+- [Data structures](doc/data_structures.md)
+- [Preprocessing](doc/preprocessing.md), [Triangle insertion](doc/triangle_insertion.md), [Mesh improvement](doc/mesh_improvement.md), [Filtering & Booleans](doc/filtering_and_booleans.md)
+- [Envelope & AABB](doc/envelope_and_aabb.md)
+
 ## Installation via CMake
 
-Our code was originally developed on MacOS and has been tested on Linux and Windows. We provide the commands for installing fTetWild in MacOS:
+Our code was originally developed on MacOS and has been tested on Linux and Windows.
 
 - Clone the repository into your local machine:
 
@@ -70,24 +81,25 @@ cmake ..
 make
 ```
 
-You may need to install `gmp` before compiling the code. You can install it via
+No system packages are required by default. All dependencies are fetched automatically at configure time via CMake's `FetchContent`.
 
-- [homebrew](https://brew.sh/) on mac:
+**Optional: GMP for exact rational arithmetic**
+
+GMP is no longer required. By default fTetWild uses a `long double` fallback for the AMIPS energy stabilisation step. To opt in to the original exact GMP-backed implementation:
+
 ```bash
-brew install gmp
-```
-- Package manager on Unix:
-```
-sudo apt-get install gmp
-```
-- [Conda](https://anaconda.org) on Windows:
-```
-conda install -c conda-forge mpir
+cmake .. -DFLOAT_TETWILD_USE_GMP=ON
 ```
 
-**Note Windows** The executable needs that the file `mpir.dll` is in the same directiory of `FloatTetwild_bin.exe`. Once you compliled the code, copy `mpir.dll` (e.g., `<conda_dir>\Library\bin`) to the directoy containing `FloatTetwild_bin.exe`.
+You will then need GMP installed:
 
-**Note** if cmake cannot find gmp you need to export the envirnement variable `GMP_INC` and `GMP_LIB` to the folder where you installed (e.g., `<conda_dir>\Library\include` for `GMP_INC` and `<conda_dir>\Library\lib` for `GMP_LIB`).
+- [homebrew](https://brew.sh/) on mac: `brew install gmp`
+- Package manager on Unix: `sudo apt-get install libgmp-dev`
+- [Conda](https://anaconda.org) on Windows: `conda install -c conda-forge mpir`
+
+**Note Windows** The executable needs `mpir.dll` in the same directory as `FloatTetwild_bin.exe`.
+
+**Note** if cmake cannot find GMP set the environment variables `GMP_INC` and `GMP_LIB` to the include and library directories respectively.
 
 - Check the installation:
 

--- a/build/configure.sh
+++ b/build/configure.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# fTetWild CMake configuration script.
+#
+# Usage: bash configure.sh [options] [-- extra cmake args]
+#
+# All options have sensible defaults; run with --help for the full list.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'; YELLOW='\033[1;33m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'
+BOLD='\033[1m'; RESET='\033[0m'
+
+info()  { echo -e "${GREEN}[configure]${RESET} $*"; }
+warn()  { echo -e "${YELLOW}[configure] WARNING:${RESET} $*" >&2; }
+error() { echo -e "${RED}[configure] ERROR:${RESET} $*" >&2; exit 1; }
+
+usage() {
+cat <<EOF
+${BOLD}Usage:${RESET} bash configure.sh [options] [-- cmake-extra-args...]
+
+${BOLD}Build options:${RESET}
+  --build-type TYPE         CMake build type: Release (default), Debug,
+                            RelWithDebInfo, MinSizeRel
+  --generator GEN           CMake generator: Ninja (default if available),
+                            "Unix Makefiles"
+  --install-prefix PATH     CMAKE_INSTALL_PREFIX  [default: /usr/local]
+  --jobs N                  Hint printed for the subsequent build step
+
+${BOLD}Compiler options:${RESET}
+  --cxx COMPILER            C++ compiler (e.g. g++, clang++)
+  --cc  COMPILER            C compiler   (e.g. gcc,  clang)
+  --cxx-flags FLAGS         Extra CMAKE_CXX_FLAGS (quoted)
+
+${BOLD}fTetWild feature flags:${RESET}
+  --no-tbb                  Disable TBB parallelism      [default: ON]
+  --use-float               Use float instead of double  [default: OFF]
+  --exact-envelope          Enable FastEnvelope library  [default: OFF]
+  --with-tetgen             Enable TetGen via libigl     [default: OFF]
+
+${BOLD}Sanitizers (implies --build-type=RelWithDebInfo unless set):${RESET}
+  --sanitize-address        Enable AddressSanitizer   (ASan)
+  --sanitize-memory         Enable MemorySanitizer    (MSan) — clang only
+  --sanitize-thread         Enable ThreadSanitizer    (TSan)
+  --sanitize-undefined      Enable UndefinedBehaviorSanitizer (UBSan)
+  Note: ASan and TSan/MSan are mutually exclusive.
+
+${BOLD}Test / output options:${RESET}
+  --no-tests                Disable unit test target     [default: ON]
+  --verbose                 CMAKE_VERBOSE_MAKEFILE=ON
+  --no-compile-commands     Disable compile_commands.json generation
+
+${BOLD}Dependency / path options:${RESET}
+  --gmp-inc PATH            GMP include directory (if not auto-detected)
+  --gmp-lib PATH            GMP library directory (if not auto-detected)
+  --third-party-dir DIR     Alternate directory for 3rd-party sources
+  --offline                 FETCHCONTENT_UPDATES_DISCONNECTED=ON
+                            (skip network checks for already-fetched deps)
+
+${BOLD}Misc:${RESET}
+  --dry-run                 Print the cmake command without running it
+  -h, --help                Show this help message
+
+${BOLD}Examples:${RESET}
+  bash configure.sh
+  bash configure.sh --build-type Debug --sanitize-address
+  bash configure.sh --build-type RelWithDebInfo --sanitize-undefined --cxx clang++
+  bash configure.sh --exact-envelope --no-tbb
+  bash configure.sh --offline -- -DCMAKE_VERBOSE_MAKEFILE=ON
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+BUILD_TYPE="Release"
+GENERATOR=""                   # auto-detected below
+INSTALL_PREFIX=""
+JOBS=""
+
+CXX_COMPILER=""
+C_COMPILER=""
+CXX_FLAGS=""
+
+ENABLE_TBB=ON
+USE_FLOAT=OFF
+EXACT_ENVELOPE=OFF
+WITH_TETGEN=OFF
+
+WITH_SANITIZERS=OFF
+SANITIZE_ADDRESS=OFF
+SANITIZE_MEMORY=OFF
+SANITIZE_THREAD=OFF
+SANITIZE_UNDEFINED=OFF
+
+BUILD_TESTING=ON
+VERBOSE=OFF
+EXPORT_COMPILE_COMMANDS=ON
+
+GMP_INC=""
+GMP_LIB=""
+THIRD_PARTY_DIR=""
+OFFLINE=OFF
+
+DRY_RUN=OFF
+
+EXTRA_ARGS=()
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build-type)        BUILD_TYPE="$2";        shift 2 ;;
+        --build-type=*)      BUILD_TYPE="${1#*=}";   shift   ;;
+        --generator)         GENERATOR="$2";         shift 2 ;;
+        --generator=*)       GENERATOR="${1#*=}";    shift   ;;
+        --install-prefix)    INSTALL_PREFIX="$2";    shift 2 ;;
+        --install-prefix=*)  INSTALL_PREFIX="${1#*=}"; shift ;;
+        --jobs)              JOBS="$2";              shift 2 ;;
+        --jobs=*)            JOBS="${1#*=}";         shift   ;;
+
+        --cxx)               CXX_COMPILER="$2";      shift 2 ;;
+        --cxx=*)             CXX_COMPILER="${1#*=}"; shift   ;;
+        --cc)                C_COMPILER="$2";        shift 2 ;;
+        --cc=*)              C_COMPILER="${1#*=}";   shift   ;;
+        --cxx-flags)         CXX_FLAGS="$2";         shift 2 ;;
+        --cxx-flags=*)       CXX_FLAGS="${1#*=}";    shift   ;;
+
+        --no-tbb)            ENABLE_TBB=OFF;         shift   ;;
+        --use-float)         USE_FLOAT=ON;           shift   ;;
+        --exact-envelope)    EXACT_ENVELOPE=ON;      shift   ;;
+        --with-tetgen)       WITH_TETGEN=ON;         shift   ;;
+
+        --sanitize-address)  SANITIZE_ADDRESS=ON;   WITH_SANITIZERS=ON; shift ;;
+        --sanitize-memory)   SANITIZE_MEMORY=ON;    WITH_SANITIZERS=ON; shift ;;
+        --sanitize-thread)   SANITIZE_THREAD=ON;    WITH_SANITIZERS=ON; shift ;;
+        --sanitize-undefined) SANITIZE_UNDEFINED=ON; WITH_SANITIZERS=ON; shift ;;
+
+        --no-tests)          BUILD_TESTING=OFF;      shift   ;;
+        --verbose)           VERBOSE=ON;             shift   ;;
+        --no-compile-commands) EXPORT_COMPILE_COMMANDS=OFF; shift ;;
+
+        --gmp-inc)           GMP_INC="$2";           shift 2 ;;
+        --gmp-inc=*)         GMP_INC="${1#*=}";      shift   ;;
+        --gmp-lib)           GMP_LIB="$2";           shift 2 ;;
+        --gmp-lib=*)         GMP_LIB="${1#*=}";      shift   ;;
+        --third-party-dir)   THIRD_PARTY_DIR="$2";   shift 2 ;;
+        --third-party-dir=*) THIRD_PARTY_DIR="${1#*=}"; shift ;;
+        --offline)           OFFLINE=ON;             shift   ;;
+
+        --dry-run)           DRY_RUN=ON;             shift   ;;
+        -h|--help)           usage; exit 0 ;;
+
+        --)  shift; EXTRA_ARGS+=("$@"); break ;;
+        -D*) EXTRA_ARGS+=("$1"); shift ;;           # raw -D pass-through
+        *)   error "Unknown option: $1\nRun with --help for usage." ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+valid_build_types="Release Debug RelWithDebInfo MinSizeRel"
+if [[ ! " $valid_build_types " =~ " $BUILD_TYPE " ]]; then
+    error "Invalid --build-type '$BUILD_TYPE'. Valid: $valid_build_types"
+fi
+
+if [[ "$SANITIZE_ADDRESS" == "ON" && ("$SANITIZE_THREAD" == "ON" || "$SANITIZE_MEMORY" == "ON") ]]; then
+    error "ASan is incompatible with TSan/MSan. Choose one set."
+fi
+
+if [[ "$WITH_SANITIZERS" == "ON" && "$BUILD_TYPE" == "Release" ]]; then
+    warn "Sanitizers are enabled but build type is Release."
+    warn "Switching to RelWithDebInfo for useful stack traces."
+    BUILD_TYPE="RelWithDebInfo"
+fi
+
+if [[ "$SANITIZE_MEMORY" == "ON" ]]; then
+    if ! "${CXX_COMPILER:-c++}" --version 2>&1 | grep -qi clang; then
+        warn "MSan is only reliable with Clang. Consider --cxx clang++."
+    fi
+fi
+
+if [[ "$USE_FLOAT" == "ON" && "$EXACT_ENVELOPE" == "ON" ]]; then
+    warn "--use-float with --exact-envelope has not been tested; proceed with caution."
+fi
+
+# ---------------------------------------------------------------------------
+# Auto-detect generator
+# ---------------------------------------------------------------------------
+if [[ -z "$GENERATOR" ]]; then
+    if command -v ninja &>/dev/null; then
+        GENERATOR="Ninja"
+    else
+        GENERATOR="Unix Makefiles"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Locate source directory (one level above this script)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Assemble cmake arguments
+# ---------------------------------------------------------------------------
+CMAKE_ARGS=(
+    -G "${GENERATOR}"
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
+    -DCMAKE_EXPORT_COMPILE_COMMANDS="${EXPORT_COMPILE_COMMANDS}"
+    -DBUILD_TESTING="${BUILD_TESTING}"
+    -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE}"
+
+    # fTetWild feature flags
+    -DFLOAT_TETWILD_ENABLE_TBB="${ENABLE_TBB}"
+    -DFLOAT_TETWILD_USE_FLOAT="${USE_FLOAT}"
+    -DFLOAT_TETWILD_WITH_EXACT_ENVELOPE="${EXACT_ENVELOPE}"
+    -DFLOAT_TETWILD_WITH_SANITIZERS="${WITH_SANITIZERS}"
+
+    # Sanitizers
+    -DSANITIZE_ADDRESS="${SANITIZE_ADDRESS}"
+    -DSANITIZE_MEMORY="${SANITIZE_MEMORY}"
+    -DSANITIZE_THREAD="${SANITIZE_THREAD}"
+    -DSANITIZE_UNDEFINED="${SANITIZE_UNDEFINED}"
+
+    # libigl extras
+    -DLIBIGL_WITH_TETGEN="${WITH_TETGEN}"
+    -DLIBIGL_WITH_PREDICATES=ON
+
+    # FetchContent
+    -DFETCHCONTENT_UPDATES_DISCONNECTED="${OFFLINE}"
+)
+
+[[ -n "$INSTALL_PREFIX"  ]] && CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}")
+[[ -n "$CXX_COMPILER"   ]] && CMAKE_ARGS+=(-DCMAKE_CXX_COMPILER="${CXX_COMPILER}")
+[[ -n "$C_COMPILER"     ]] && CMAKE_ARGS+=(-DCMAKE_C_COMPILER="${C_COMPILER}")
+[[ -n "$CXX_FLAGS"      ]] && CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="${CXX_FLAGS}")
+[[ -n "$GMP_INC"        ]] && CMAKE_ARGS+=(-DGMP_INC="${GMP_INC}")
+[[ -n "$GMP_LIB"        ]] && CMAKE_ARGS+=(-DGMP_LIB="${GMP_LIB}")
+[[ -n "$THIRD_PARTY_DIR" ]] && CMAKE_ARGS+=(-DINPUT_THIRD_PARTY_DIR="${THIRD_PARTY_DIR}")
+
+# User pass-through
+CMAKE_ARGS+=("${EXTRA_ARGS[@]}")
+
+# ---------------------------------------------------------------------------
+# Print configuration summary
+# ---------------------------------------------------------------------------
+echo ""
+echo -e "${BOLD}${CYAN}━━━  fTetWild configuration  ━━━${RESET}"
+printf "  %-28s %s\n" "Source dir:"        "${SOURCE_DIR}"
+printf "  %-28s %s\n" "Build dir:"         "$(pwd)"
+printf "  %-28s %s\n" "Generator:"         "${GENERATOR}"
+printf "  %-28s %s\n" "Build type:"        "${BUILD_TYPE}"
+[[ -n "$INSTALL_PREFIX" ]] && \
+printf "  %-28s %s\n" "Install prefix:"    "${INSTALL_PREFIX}"
+echo ""
+printf "  %-28s %s\n" "TBB parallelism:"   "${ENABLE_TBB}"
+printf "  %-28s %s\n" "Scalar type:"       "$( [[ $USE_FLOAT == ON ]] && echo float || echo double )"
+printf "  %-28s %s\n" "Exact envelope:"    "${EXACT_ENVELOPE}"
+printf "  %-28s %s\n" "TetGen:"            "${WITH_TETGEN}"
+printf "  %-28s %s\n" "Build tests:"       "${BUILD_TESTING}"
+printf "  %-28s %s\n" "compile_commands:"  "${EXPORT_COMPILE_COMMANDS}"
+printf "  %-28s %s\n" "Verbose build:"     "${VERBOSE}"
+printf "  %-28s %s\n" "Offline deps:"      "${OFFLINE}"
+echo ""
+if [[ "$WITH_SANITIZERS" == "ON" ]]; then
+    SANS=()
+    [[ $SANITIZE_ADDRESS   == ON ]] && SANS+=(ASan)
+    [[ $SANITIZE_MEMORY    == ON ]] && SANS+=(MSan)
+    [[ $SANITIZE_THREAD    == ON ]] && SANS+=(TSan)
+    [[ $SANITIZE_UNDEFINED == ON ]] && SANS+=(UBSan)
+    printf "  %-28s %s\n" "Sanitizers:" "${SANS[*]}"
+    echo ""
+fi
+[[ -n "$CXX_COMPILER" ]] && printf "  %-28s %s\n" "C++ compiler:" "${CXX_COMPILER}"
+[[ -n "$C_COMPILER"   ]] && printf "  %-28s %s\n" "C compiler:"   "${C_COMPILER}"
+[[ -n "$CXX_FLAGS"    ]] && printf "  %-28s %s\n" "Extra CXX flags:" "${CXX_FLAGS}"
+[[ -n "$GMP_INC"      ]] && printf "  %-28s %s\n" "GMP include:" "${GMP_INC}"
+[[ -n "$GMP_LIB"      ]] && printf "  %-28s %s\n" "GMP lib dir:" "${GMP_LIB}"
+[[ ${#EXTRA_ARGS[@]}  -gt 0 ]] && \
+printf "  %-28s %s\n" "Extra cmake args:" "${EXTRA_ARGS[*]}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Run (or print) cmake
+# ---------------------------------------------------------------------------
+CMD=(cmake "${SOURCE_DIR}" "${CMAKE_ARGS[@]}")
+
+if [[ "$DRY_RUN" == "ON" ]]; then
+    echo -e "${YELLOW}[dry-run]${RESET} Would execute:"
+    echo "  ${CMD[*]}"
+    echo ""
+    exit 0
+fi
+
+info "Running cmake..."
+echo ""
+"${CMD[@]}"
+
+echo ""
+info "Configuration complete."
+if [[ -n "$JOBS" ]]; then
+    info "Build with:  cmake --build . --parallel ${JOBS}"
+else
+    info "Build with:  cmake --build . --parallel \$(nproc)"
+fi
+[[ "$BUILD_TESTING" == "ON" ]] && info "Test  with:  ctest --output-on-failure"
+echo ""

--- a/build/configure.sh
+++ b/build/configure.sh
@@ -39,6 +39,9 @@ ${BOLD}fTetWild feature flags:${RESET}
   --use-float               Use float instead of double  [default: OFF]
   --exact-envelope          Enable FastEnvelope library  [default: OFF]
   --with-tetgen             Enable TetGen via libigl     [default: OFF]
+  --with-gmp                Use GMP for exact rational AMIPS energy
+                            stabilisation. Requires libgmp-dev.
+                            Default: OFF (long double fallback is used)
 
 ${BOLD}Sanitizers (implies --build-type=RelWithDebInfo unless set):${RESET}
   --sanitize-address        Enable AddressSanitizer   (ASan)
@@ -68,6 +71,7 @@ ${BOLD}Examples:${RESET}
   bash configure.sh --build-type Debug --sanitize-address
   bash configure.sh --build-type RelWithDebInfo --sanitize-undefined --cxx clang++
   bash configure.sh --exact-envelope --no-tbb
+  bash configure.sh --with-gmp                   # enable exact GMP rational arithmetic
   bash configure.sh --offline -- -DCMAKE_VERBOSE_MAKEFILE=ON
 EOF
 }
@@ -88,6 +92,7 @@ ENABLE_TBB=ON
 USE_FLOAT=OFF
 EXACT_ENVELOPE=OFF
 WITH_TETGEN=OFF
+USE_GMP=OFF
 
 WITH_SANITIZERS=OFF
 SANITIZE_ADDRESS=OFF
@@ -133,6 +138,7 @@ while [[ $# -gt 0 ]]; do
         --use-float)         USE_FLOAT=ON;           shift   ;;
         --exact-envelope)    EXACT_ENVELOPE=ON;      shift   ;;
         --with-tetgen)       WITH_TETGEN=ON;         shift   ;;
+        --with-gmp)          USE_GMP=ON;             shift   ;;
 
         --sanitize-address)  SANITIZE_ADDRESS=ON;   WITH_SANITIZERS=ON; shift ;;
         --sanitize-memory)   SANITIZE_MEMORY=ON;    WITH_SANITIZERS=ON; shift ;;
@@ -220,6 +226,7 @@ CMAKE_ARGS=(
     -DFLOAT_TETWILD_USE_FLOAT="${USE_FLOAT}"
     -DFLOAT_TETWILD_WITH_EXACT_ENVELOPE="${EXACT_ENVELOPE}"
     -DFLOAT_TETWILD_WITH_SANITIZERS="${WITH_SANITIZERS}"
+    -DFLOAT_TETWILD_USE_GMP="${USE_GMP}"
 
     # Sanitizers
     -DSANITIZE_ADDRESS="${SANITIZE_ADDRESS}"
@@ -262,6 +269,7 @@ printf "  %-28s %s\n" "TBB parallelism:"   "${ENABLE_TBB}"
 printf "  %-28s %s\n" "Scalar type:"       "$( [[ $USE_FLOAT == ON ]] && echo float || echo double )"
 printf "  %-28s %s\n" "Exact envelope:"    "${EXACT_ENVELOPE}"
 printf "  %-28s %s\n" "TetGen:"            "${WITH_TETGEN}"
+printf "  %-28s %s\n" "GMP rational:"      "$( [[ $USE_GMP == ON ]] && echo "ON (exact)" || echo "OFF (long double fallback)" )"
 printf "  %-28s %s\n" "Build tests:"       "${BUILD_TESTING}"
 printf "  %-28s %s\n" "compile_commands:"  "${EXPORT_COMPILE_COMMANDS}"
 printf "  %-28s %s\n" "Verbose build:"     "${VERBOSE}"

--- a/doc/data_structures.md
+++ b/doc/data_structures.md
@@ -1,0 +1,165 @@
+# Data Structures
+
+All types live in `namespace floatTetWild`.
+
+---
+
+## Scalar and Linear Algebra Types (`src/Types.hpp`)
+
+```cpp
+typedef double Scalar;          // float if FLOAT_TETWILD_USE_FLOAT is defined
+
+typedef Eigen::Matrix<Scalar, 3, 1> Vector3;
+typedef Eigen::Matrix<Scalar, 2, 1> Vector2;
+typedef Eigen::Matrix<Scalar, 3, 3> Matrix3;
+typedef Eigen::Matrix<int, 4, 1>    Vector4i;
+typedef Eigen::Matrix<int, 3, 1>    Vector3i;
+typedef Eigen::Matrix<int, 2, 1>    Vector2i;
+```
+
+Numerical tolerances defined as preprocessor constants:
+- `SCALAR_ZERO` = 1e-8 (doubles) / 1e-6 (floats)
+- `SCALAR_ZERO_2` = 1e-16 (doubles)
+
+---
+
+## MeshVertex (`src/Mesh.hpp`)
+
+Represents a vertex of the output tetrahedral mesh.
+
+```cpp
+class MeshVertex {
+    Vector3 pos;                 // 3D position
+    std::vector<int> conn_tets;  // indices of incident tetrahedra
+
+    bool is_on_surface   = false;
+    bool is_on_boundary  = false;  // open boundary of input
+    bool is_on_cut       = false;
+    bool is_on_bbox      = false;  // vertex is on bounding box
+    bool is_outside      = false;
+
+    bool is_removed  = false;  // lazy-deleted
+    bool is_freezed  = false;  // not moved during optimization
+
+    Scalar sizing_scalar = 1;  // local sizing field multiplier
+    Scalar scalar        = 0;  // winding number / output value
+};
+```
+
+**Lazy deletion**: vertices are never physically erased from `Mesh::tet_vertices`. Instead `is_removed = true` marks them as free slots. `Mesh::v_empty_start` is the cursor to the first free slot, reset by `reset_v_empty_start()`.
+
+---
+
+## MeshTet (`src/Mesh.hpp`)
+
+Represents a tetrahedron. Each tet stores its 4 vertex indices and per-face metadata.
+
+```cpp
+class MeshTet {
+    Vector4i indices;  // global vertex indices [v0, v1, v2, v3]
+
+    // Per-face flags (4 faces, indexed j = 0..3; face j is opposite vertex j)
+    std::array<char, 4> is_surface_fs;  // NOT_SURFACE / KNOWN_SURFACE / KNOWN_NOT_SURFACE
+    std::array<char, 4> is_bbox_fs;     // NOT_BBOX (-1) or tag id (≥0)
+    std::array<int,  4> opp_t_ids;      // opposite tet id (OPP_T_ID_UNKNOWN / OPP_T_ID_BOUNDARY / index)
+    std::array<char, 4> surface_tags;   // input face tag per face
+
+    Scalar quality   = 0;      // conformal AMIPS energy
+    Scalar scalar    = 0;      // winding number at centroid
+    bool is_removed  = false;  // lazy-deleted
+    bool is_outside  = false;  // outside the input surface
+};
+```
+
+Face indexing convention: **face j is the face opposite to vertex j**, i.e., the face formed by the three vertices that are _not_ `indices[j]`. Helper methods:
+- `find(v)` — returns the local index (0–3) of vertex `v`
+- `find_opp(v0, v1, v2)` — returns the local index of the vertex not in {v0,v1,v2}
+
+Sentinel values:
+```cpp
+#define NOT_SURFACE       SCHAR_MAX    // face not yet classified as surface
+#define KNOWN_NOT_SURFACE -SCHAR_MAX/2
+#define KNOWN_SURFACE      SCHAR_MAX/2
+#define NOT_BBOX          -1
+#define OPP_T_ID_UNKNOWN  -2
+#define OPP_T_ID_BOUNDARY -1
+#define MAX_ENERGY         1e50
+```
+
+---
+
+## Mesh (`src/Mesh.hpp`)
+
+The top-level mesh container.
+
+```cpp
+class Mesh {
+    std::vector<MeshVertex> tet_vertices;
+    std::vector<MeshTet>    tets;
+    Parameters params;
+
+    int  t_empty_start = 0;  // first free tet slot
+    int  v_empty_start = 0;  // first free vertex slot
+    bool is_limit_length       = true;
+    bool is_closed             = true;
+    bool is_input_all_inserted = false;
+    bool is_coarsening         = false;
+};
+```
+
+Key helpers:
+- `get_v_num()` / `get_t_num()` — count of non-removed vertices / tets
+- `get_max_energy()` / `get_avg_energy()` — AMIPS statistics over live tets
+- `reset_t_empty_start()` / `reset_v_empty_start()` — recompute empty-slot cursors
+- `one_ring_vertex_sets(threshold, concurrent_sets, serial_set)` — partition vertices into independent sets for TBB parallel smoothing
+- `partition(n_parts, tets_id)` — spatial partitioning for parallel operations
+
+---
+
+## Parameters (`src/Parameters.h`)
+
+Holds all algorithm parameters. Computed values are populated by `Parameters::init(bbox_diag_length)` which must be called once after loading the input.
+
+### User-set parameters
+
+| Field | Default | Description |
+|---|---|---|
+| `eps_rel` | 1e-3 | ε = eps_rel × bbox diagonal |
+| `ideal_edge_length_rel` | 1/20 | ℓ = ideal_edge_length_rel × bbox diagonal |
+| `ideal_edge_length_abs` | 0 | Absolute ℓ (overrides relative if > 0) |
+| `stop_energy` | 10 | Stop optimization when max AMIPS < this |
+| `max_its` | 80 | Maximum optimization iterations |
+| `smooth_open_boundary` | false | Laplacian-smooth open boundary faces |
+| `manifold_surface` | false | Force manifold output surface |
+| `disable_filtering` | false | Skip exterior tet removal |
+| `use_floodfill` | false | Use flood-fill instead of winding number |
+| `use_general_wn` | false | Generalized winding number |
+| `coarsen` | false | Aggressively coarsen output |
+| `num_threads` | max | TBB thread count |
+
+### Derived parameters (set by `init()`)
+
+| Field | Formula |
+|---|---|
+| `ideal_edge_length` | `bbox_diag_length × ideal_edge_length_rel` |
+| `eps_input` | `bbox_diag_length × eps_rel` |
+| `eps` | `eps_input` adjusted for stage |
+| `split_threshold` | `ideal_edge_length × 4/3` |
+| `collapse_threshold` | `ideal_edge_length × 4/5` |
+| `eps_simplification` | `eps × 0.8` |
+| `eps_coplanar` | `min(eps × 0.2, bbox_diag × 1e-6)` |
+| `min_edge_length` | `bbox_diag × eps_rel` |
+
+---
+
+## Statistics (`src/Statistics.h`)
+
+Thread-safe singleton collecting timing and quality data for each pipeline stage. Written to a CSV file at the end of execution. Stage IDs:
+
+```
+0 = init        1 = preprocessing   2 = tetrahedralization
+3 = cutting     4 = optimization    5 = winding_number
+6 = splitting   7 = collapsing      8 = swapping   9 = smoothing
+```
+
+CSV columns: `stage_id, time_s, v_count, t_count, max_energy, avg_energy, uninserted_faces, peak_mem_mb`

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -1,0 +1,54 @@
+# Dependencies
+
+## System dependency (must be installed manually)
+
+| Library | Role | Install |
+|---|---|---|
+| **GMP** | Exact arithmetic for AMIPS energy stabilisation and geometric predicates | `sudo apt-get install libgmp-dev` / `brew install gmp` |
+
+CMake hard-fails with `Cannot find GMP` if absent. Override detected paths with the `GMP_INC` / `GMP_LIB` environment variables, or the `--gmp-inc` / `--gmp-lib` flags in `build/configure.sh`.
+
+---
+
+## FetchContent dependencies (auto-downloaded at configure time)
+
+| Library | Pinned version | Role |
+|---|---|---|
+| **CLI11** | v2.5.0 | Command-line argument parsing (`src/main.cpp`) |
+| **fmt** | v11.2.0 | String formatting; used by spdlog |
+| **spdlog** | v1.15.3 | Structured logging (`src/Logger.hpp`); configured to use external fmt |
+| **libigl** | v2.6.0 | Geometry utilities: `igl::Timer`, `igl::write_triangle_mesh`, `igl::default_num_threads`; also pulls in Eigen |
+| **Eigen** | (via libigl) | All linear algebra — `Vector3`, `Matrix3`, `MatrixXd`, etc. |
+| **predicates** | (via libigl) | Shewchuk's exact orient/insphere floating-point predicates |
+| **geogram** | v1.9.6 | Delaunay 3D tetrahedralization, AABB trees, mesh I/O; built library-only (no GUI, no Lua) |
+| **oneTBB** | v2022.2.0 | Intel Threading Building Blocks for parallel preprocessing and vertex smoothing; only when `FLOAT_TETWILD_ENABLE_TBB=ON` (default) |
+| **nlohmann/json** | jdumas fork (pinned commit) | JSON parsing for CSG tree files (`--csg`) |
+| **Catch2** | v3.5.3 | Unit test framework; only when `BUILD_TESTING=ON` |
+| **sanitizers-cmake** | pinned commit | CMake sanitizer helpers; only when `FLOAT_TETWILD_WITH_SANITIZERS=ON` |
+| **FastEnvelope** | pinned commit | Exact envelope containment tests; only when `FLOAT_TETWILD_WITH_EXACT_ENVELOPE=ON` |
+
+---
+
+## Optional / implicit
+
+| Library | Condition |
+|---|---|
+| **Threads** | Always linked; provided by the OS (`find_package(Threads)`) |
+| **OpenMP** | Detected if available; used by libigl internally |
+| **TetGen** (via `igl::tetgen`) | Enabled with `--with-tetgen` in `configure.sh`; exposes a `--tetgen` CLI flag for comparison runs |
+
+---
+
+## Vendored in `src/external/`
+
+Bundled directly in the repository — no download needed.
+
+| File(s) | Origin / Role |
+|---|---|
+| `MshLoader.cpp/.h`, `MshSaver.cpp/.h` | PyMesh-derived `.msh` file I/O |
+| `Predicates.cpp/.hpp`, `predicates.c` | Wrapper around Shewchuk's exact predicates |
+| `Rational.h` | Exact rational arithmetic (used for unstable AMIPS energy stabilisation) |
+| `mesh_AABB.h/.cpp` | Custom geogram AABB variant with ε-tolerance proximity queries |
+| `triangle_triangle_intersection.cpp` | Guigue–Devillers triangle–triangle intersection test |
+| `bfs_orient.cpp/.h` | BFS-based mesh orientation |
+| `get_mem.cpp/.h`, `getRSS.c` | Peak memory reporting for statistics CSV |

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -1,12 +1,24 @@
 # Dependencies
 
-## System dependency (must be installed manually)
+## System dependencies
 
-| Library | Role | Install |
+GMP is **optional** since the introduction of the `long double` fallback. No system packages are required by default.
+
+| Library | Role | Required | Install |
+|---|---|---|---|
+| **GMP** | Exact rational arithmetic for AMIPS energy stabilisation | **Optional** (`-DFLOAT_TETWILD_USE_GMP=ON`) | `sudo apt-get install libgmp-dev` / `brew install gmp` |
+
+### GMP vs. long double fallback
+
+| | GMP (`FLOAT_TETWILD_USE_GMP=ON`) | Default (long double) |
 |---|---|---|
-| **GMP** | Exact arithmetic for AMIPS energy stabilisation and geometric predicates | `sudo apt-get install libgmp-dev` / `brew install gmp` |
+| AMIPS precision | Exact rational (arbitrary precision) | 80-bit extended precision (x86/x86_64) |
+| ARM / Apple Silicon | Exact | Same precision as double — instability may reappear on very degenerate elements |
+| License | LGPL v3 | — |
+| System install required | Yes | No |
 
-CMake hard-fails with `Cannot find GMP` if absent. Override detected paths with the `GMP_INC` / `GMP_LIB` environment variables, or the `--gmp-inc` / `--gmp-lib` flags in `build/configure.sh`.
+Enable GMP via `configure.sh --with-gmp` or by passing `-DFLOAT_TETWILD_USE_GMP=ON` to CMake directly.
+When GMP is enabled, override detected paths with the `GMP_INC` / `GMP_LIB` environment variables, or the `--gmp-inc` / `--gmp-lib` flags in `build/configure.sh`.
 
 ---
 

--- a/doc/envelope_and_aabb.md
+++ b/doc/envelope_and_aabb.md
@@ -1,0 +1,108 @@
+# Envelope and AABB Structures
+
+**Source**: `src/AABBWrapper.h/.cpp`, `src/external/mesh_AABB.h/.cpp`
+
+---
+
+## The ε-Envelope
+
+The ε-envelope is the central robustness mechanism in fTetWild. It is a tube of radius ε centered on the input surface: every face of the output mesh that corresponds to an input triangle is guaranteed to lie within this tube.
+
+The envelope allows the algorithm to:
+- Tolerate self-intersections, gaps, and degeneracies in the input (all imperfections smaller than ε are resolved automatically).
+- Use floating-point arithmetic throughout without exact arithmetic, since small errors are absorbed by ε.
+- Perform snapping during triangle insertion by moving vertices onto the insertion plane without violating correctness.
+
+**Default ε**: `1e-3 × d` where d is the diagonal of the bounding box of the input.
+
+---
+
+## AABBWrapper (`src/AABBWrapper.h`)
+
+`AABBWrapper` is the central proximity-query object. It wraps multiple AABB trees and exposes uniform query APIs for the two envelope implementations.
+
+### Trees Maintained
+
+```cpp
+class AABBWrapper {
+    const GEO::Mesh& sf_mesh;           // original input surface
+    GEO::Mesh        b_mesh;            // background mesh (input vertices + grid points)
+    GEO::Mesh        tmp_b_mesh;        // temporary background mesh
+
+    MeshFacetsAABBWithEps sf_tree;      // AABB for sf_mesh
+    shared_ptr<MeshFacetsAABBWithEps> b_tree;     // AABB for b_mesh
+    shared_ptr<MeshFacetsAABBWithEps> tmp_b_tree; // AABB for tmp_b_mesh
+
+#ifdef NEW_ENVELOPE
+    // Exact envelope instances (when FLOAT_TETWILD_WITH_EXACT_ENVELOPE is ON)
+    fastEnvelope::FastEnvelope sf_tree_exact;
+    fastEnvelope::FastEnvelope sf_tree_exact_simplify;
+    fastEnvelope::FastEnvelope b_tree_exact;
+    fastEnvelope::FastEnvelope tmp_b_tree_exact;
+#endif
+};
+```
+
+### Key Query Operations
+
+All geometry queries in the mesh improvement and insertion stages go through `AABBWrapper`:
+
+- **`is_out_envelope(triangle, tree, params)`** — returns true if the triangle lies outside the ε-envelope (used to reject local operations that would violate the envelope).
+- **`get_sf_diag()`** — returns the bounding box diagonal of `sf_mesh`, used to compute ε and ℓ from their relative values.
+
+### Initialization Sequence
+
+```cpp
+// 1. Wrap the input surface
+AABBWrapper tree(sf_mesh);
+
+// 2. Initialize the exact envelope (only if NEW_ENVELOPE defined)
+tree.init_sf_tree(input_vertices, input_faces, params.eps);
+
+// 3. After preprocessing: build the background mesh tree
+tree.init_b_mesh_and_tree(input_vertices, input_faces, mesh);
+```
+
+---
+
+## MeshFacetsAABBWithEps (`src/external/mesh_AABB.h`)
+
+A custom AABB tree built on top of geogram's `GEO::MeshFacetsAABB`. Extended with an epsilon tolerance for proximity queries.
+
+**Envelope containment check**: To test if a triangle T is inside the ε-envelope, the algorithm:
+1. Samples T with a uniform point set at spacing proportional to ε.
+2. For each sample point, queries the AABB for the nearest input face.
+3. If all sample distances to the nearest face are ≤ ε, the triangle is inside the envelope.
+
+Sampling introduces a conservative over-estimate: the sampling error is explicitly compensated so that the check is never falsely accepting (i.e., it may reject a triangle that is actually inside the envelope, but never accepts one that is outside).
+
+---
+
+## Exact Envelope (Optional)
+
+When compiled with `-DFLOAT_TETWILD_WITH_EXACT_ENVELOPE=ON`, the preprocessor macro `NEW_ENVELOPE` is defined and the `FastEnvelope` library (github: wangbolun300/fast-envelope) is used instead of the sampling-based check.
+
+`FastEnvelope` computes an exact answer to "is triangle T inside the ε-envelope?" using a BSP-tree over the thickened input faces. This eliminates false negatives (triangles rejected by the conservative sampling check) and can improve both output quality and running time for inputs with many near-envelope triangles.
+
+The tradeoff is a significantly longer CMake configure/build time (the FastEnvelope library must be built) and a small runtime overhead for building the exact envelope structure.
+
+**Two exact trees are built for the input surface**:
+- `sf_tree_exact` — built with ε
+- `sf_tree_exact_simplify` — built with 0.8ε (for the preprocessing stage, which uses a smaller envelope)
+
+---
+
+## Envelope in Local Operations
+
+In `src/LocalOperations.h`:
+
+```cpp
+bool is_out_envelope(Mesh& mesh, int v_id, const Vector3& new_pos,
+                     const AABBWrapper& tree);
+bool is_out_boundary_envelope(const Mesh& mesh, int v_id, const Vector3& new_pos,
+                              const AABBWrapper& tree);
+```
+
+Before any local operation (split, collapse, swap, smooth) moves a vertex, these functions verify that all tracked surface faces incident to the vertex remain within ε after the move. If either returns true, the operation is rolled back.
+
+The key internal function is `sample_triangle_and_check_is_out()`, which samples a triangle and queries the AABB for the nearest face — all with a cached `prev_facet` hint to accelerate repeated queries on nearby triangles.

--- a/doc/filtering_and_booleans.md
+++ b/doc/filtering_and_booleans.md
@@ -1,0 +1,106 @@
+# Phase 4: Filtering and Boolean Operations
+
+**Source**: `src/MeshImprovement.h/.cpp`, `src/CSGTreeParser.hpp/.cpp`  
+**Key functions**: `filter_outside()`, `filter_outside_floodfill()`, `boolean_operation()`, `manifold_surface()`, `get_surface()`
+
+---
+
+## Purpose
+
+After mesh improvement, the volumetric mesh fills the entire expanded bounding box. Phase 4 classifies each tetrahedron as *inside* or *outside* the input surface and removes the outside ones, producing the final mesh conforming to the input boundary.
+
+---
+
+## Interior Classification Methods
+
+Three strategies are available, selected by command-line flags:
+
+### 1. Winding Number (default)
+
+For each non-removed tetrahedron, compute the **winding number** of its centroid with respect to the tracked surface. The winding number measures how many times the surface wraps around a point:
+- Integer values (0 or ±1) indicate points clearly inside or outside.
+- The threshold is 0.5: tetrahedra with |winding number| > 0.5 are kept as interior.
+
+Two winding number variants exist:
+- **Fast winding number** (`filter_outside(mesh)`) — uses the tracked surface, which has already been inserted into the mesh. This is the default.
+- **General winding number** (`--use-general-wn`) — uses `filter_outside(mesh, input_vertices, input_faces)`, evaluating with respect to the original input surface rather than the tracked surface.
+
+Winding numbers correctly classify interiors of non-manifold and non-orientable inputs, unlike signed distance.
+
+### 2. Flood Fill (`--use-floodfill`)
+
+`filter_outside_floodfill(mesh)` starts from tetrahedra adjacent to the bounding box (which are known to be outside) and floods inward, stopping at tracked surface faces. Any tet reachable from the bounding box without crossing a surface face is marked outside.
+
+This is simpler and faster than winding numbers but requires the inserted surface to be watertight. It is useful when the input is known to be closed and the winding number is expensive.
+
+### 3. Skip Filtering (`--disable-filtering`)
+
+No tetrahedra are removed. The full bounding-box mesh is output. Useful for debugging insertion correctness.
+
+---
+
+## Open Boundary Handling (`--smooth-open-boundary`)
+
+For inputs with open boundaries (non-closed surfaces), the filtering step must not remove tetrahedra on the open side. The `smooth_open_boundary()` function applies a few passes of Laplacian smoothing to the triangles on the open side of the surface before exterior tets are removed, producing a smoother cap over open regions.
+
+After smoothing, exterior tets are removed in the same way as the default winding number approach.
+
+---
+
+## Boolean / CSG Operations
+
+fTetWild supports approximate Boolean operations on triangle soups (union, intersection, difference) that do not need to be closed or manifold.
+
+### Simple Two-Mesh Boolean (`--op 0/1/2`)
+
+For two-mesh operations:
+1. Input meshes are tagged (face tags 1 and 2 in `input_tags`).
+2. Triangle insertion tracks the provenance of each face (which input mesh it came from).
+3. After mesh improvement, `boolean_operation(mesh, op)` evaluates the winding number of each tet's centroid separately for each input mesh.
+4. Tets are retained based on the Boolean logic:
+   - **Union (0)**: inside mesh 1 OR inside mesh 2
+   - **Intersection (1)**: inside mesh 1 AND inside mesh 2
+   - **Difference (2)**: inside mesh 1 AND NOT inside mesh 2
+
+### CSG Trees (`--csg tree.json`)
+
+A JSON CSG tree allows arbitrary combinations of Boolean operations on multiple input meshes.
+
+**JSON format**: A recursive tree where leaf nodes are mesh filenames and internal nodes are operations:
+```json
+{
+  "operation": "union",
+  "left": { "mesh": "object1.stl" },
+  "right": {
+    "operation": "difference",
+    "left": { "mesh": "object2.obj" },
+    "right": { "mesh": "object3.off" }
+  }
+}
+```
+
+`CSGTreeParser::get_meshes()` extracts the list of meshes and assigns integer IDs. After mesh improvement, `boolean_operation(mesh, csg_tree_with_ids, meshes)` computes a winding number for each mesh independently and evaluates the tree to decide which tets to retain.
+
+---
+
+## Surface Extraction
+
+After filtering, the boundary faces of the remaining tets form the output surface.
+
+### Standard (`get_surface`)
+
+Collects all non-removed tet faces that are not shared by two non-removed tets (i.e., boundary faces). These faces form the output surface mesh (V_sf, F_sf).
+
+### Manifold Output (`--manifold-surface`)
+
+The raw output surface may be non-manifold at edges shared by more than two tets, or at vertices where the surface branches. `manifold_surface()` resolves this:
+1. `manifold_edges()` — detects non-manifold edges and splits them.
+2. `manifold_vertices()` — duplicates non-manifold vertices so the surface is globally manifold (using the algorithm of Attene et al. 2009). Note: duplicate vertices share identical 3D positions; only the topological structure differs.
+
+The manifold extraction is needed when using the output as a repaired surface mesh (mesh repair application).
+
+---
+
+## Correct Tracked Surface Orientation
+
+Before filtering, `correct_tracked_surface_orientation(mesh, tree)` re-examines each tracked surface face and corrects its normal orientation based on proximity to the original input surface. This ensures the winding number computation is consistent.

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,56 @@
+# fTetWild Documentation
+
+fTetWild converts an arbitrary triangle soup into a high-quality tetrahedral mesh.
+It is robust to imperfect input (self-intersections, gaps, non-manifold geometry) and
+operates entirely in floating-point arithmetic.
+
+**Paper**: Yixin Hu, Teseo Schneider, Bolun Wang, Denis Zorin, Daniele Panozzo.
+*Fast Tetrahedral Meshing in the Wild*. ACM Transactions on Graphics (SIGGRAPH 2020).
+[`doc/paper.pdf`](paper.pdf)
+
+---
+
+## Contents
+
+### Getting started
+| | |
+|---|---|
+| [Dependencies](dependencies.md) | System requirements, FetchContent libraries, vendored code |
+| [Library API](library_api.md) | CMake integration, C++ API, minimal example, parameter reference |
+
+### Algorithm
+| | |
+|---|---|
+| [Overview](overview.md) | The four pipeline phases, key properties, comparison with TetWild |
+| [Phase 1 — Preprocessing](preprocessing.md) | Input simplification, parallel edge collapsing, envelope checking |
+| [Phase 2 — Triangle Insertion](triangle_insertion.md) | Background mesh, snapping, tet-subdivision table, retry loop |
+| [Phase 3 — Mesh Improvement](mesh_improvement.md) | AMIPS energy, edge split/collapse/swap, parallel vertex smoothing |
+| [Phase 4 — Filtering & Booleans](filtering_and_booleans.md) | Winding number, flood-fill, CSG trees, manifold extraction |
+
+### Reference
+| | |
+|---|---|
+| [Data Structures](data_structures.md) | `Mesh`, `MeshVertex`, `MeshTet`, `Parameters`, `Statistics` |
+| [Envelope & AABB](envelope_and_aabb.md) | `AABBWrapper`, sampling-based and exact envelope checks |
+
+---
+
+## Quick build reference
+
+```bash
+# Install system dependency (Ubuntu/Debian)
+sudo apt-get install libgmp-dev
+
+# Configure and build
+cd build
+bash configure.sh          # Release + TBB, all defaults
+cmake --build . --parallel $(nproc)
+
+# Run tests
+ctest --output-on-failure
+
+# Mesh a surface
+./FloatTetwild_bin -i input.obj -o output.msh
+```
+
+See `build/configure.sh --help` for all configuration options.

--- a/doc/index.md
+++ b/doc/index.md
@@ -38,13 +38,15 @@ operates entirely in floating-point arithmetic.
 ## Quick build reference
 
 ```bash
-# Install system dependency (Ubuntu/Debian)
-sudo apt-get install libgmp-dev
+# No system packages required by default — all deps are fetched automatically.
 
 # Configure and build
 cd build
-bash configure.sh          # Release + TBB, all defaults
+bash configure.sh          # Release + TBB, long double fallback (no GMP needed)
 cmake --build . --parallel $(nproc)
+
+# Optional: enable exact GMP rational arithmetic (requires libgmp-dev)
+bash configure.sh --with-gmp
 
 # Run tests
 ctest --output-on-failure

--- a/doc/library_api.md
+++ b/doc/library_api.md
@@ -1,0 +1,185 @@
+# Using fTetWild as a C++ Library
+
+fTetWild exposes a single-function API for integration into other C++ projects.
+
+---
+
+## CMake Integration
+
+Add fTetWild as a subdirectory (or via FetchContent) and link against the `FloatTetwild` target:
+
+```cmake
+add_subdirectory(fTetWild)
+target_link_libraries(my_target PRIVATE FloatTetwild)
+```
+
+All transitive dependencies (libigl, geogram, TBB, spdlog, GMP, etc.) are pulled in automatically through the CMake target.
+
+The headers are installed under the `floattetwild/` include prefix (matching the `#include <floattetwild/...>` style used in the source).
+
+---
+
+## API
+
+**Header**: `<floattetwild/FloatTetwild.h>`
+
+```cpp
+namespace floatTetWild {
+
+int tetrahedralization(
+    GEO::Mesh&       sf_mesh,       // [in]  input surface mesh in geogram format
+    Parameters       params,        // [in]  algorithm parameters (copied by value)
+    Eigen::MatrixXd& VO,            // [out] output vertices, shape (N, 3)
+    Eigen::MatrixXi& TO,            // [out] output tetrahedra, shape (M, 4)
+    int              boolean_op  = -1,     // [in]  -1 = none, 0 = union, 1 = intersection, 2 = diff
+    bool             skip_simplify = false // [in]  skip preprocessing step
+);
+
+}
+```
+
+Returns `EXIT_SUCCESS` (0) on success, `EXIT_FAILURE` (1) if the input is empty or malformed.
+
+---
+
+## Minimal Example
+
+```cpp
+#include <floattetwild/FloatTetwild.h>
+#include <floattetwild/MeshIO.hpp>
+#include <floattetwild/Logger.hpp>
+#include <floattetwild/Parameters.h>
+
+#include <geogram/basic/common.h>
+#include <geogram/mesh/mesh.h>
+#include <geogram/mesh/mesh_io.h>
+
+#include <Eigen/Dense>
+
+int main() {
+    // Initialize geogram (required once per process)
+    GEO::initialize();
+
+    // Initialize fTetWild's spdlog logger
+    floatTetWild::Logger::init(/*use_cout=*/true, /*log_file=*/"");
+
+    // Load input surface mesh into geogram
+    GEO::Mesh sf_mesh;
+    GEO::mesh_load("input.obj", sf_mesh);
+
+    // Configure parameters
+    floatTetWild::Parameters params;
+    params.eps_rel             = 1e-3;   // envelope size: 0.1% of bbox diagonal
+    params.ideal_edge_length_rel = 0.05; // target edge length: 5% of bbox diagonal
+    params.stop_energy         = 10.0;   // stop when max AMIPS < 10
+    params.max_its             = 80;     // max optimization iterations
+
+    // Run
+    Eigen::MatrixXd V;
+    Eigen::MatrixXi T;
+    int result = floatTetWild::tetrahedralization(sf_mesh, params, V, T);
+
+    if (result != EXIT_SUCCESS) {
+        // V and T contain an empty or partial mesh
+        return 1;
+    }
+
+    // V: (N×3) matrix of vertex positions
+    // T: (M×4) matrix of tetrahedron vertex indices (0-based)
+    printf("Vertices: %ld  Tetrahedra: %ld\n", V.rows(), T.rows());
+    return 0;
+}
+```
+
+---
+
+## Loading Input with MeshIO
+
+To avoid the geogram `mesh_load` dependency for formats other than what geogram supports natively, use fTetWild's own `MeshIO` which handles `.off`, `.obj`, `.stl`, `.ply`:
+
+```cpp
+#include <floattetwild/MeshIO.hpp>
+
+std::vector<floatTetWild::Vector3>  input_vertices;
+std::vector<floatTetWild::Vector3i> input_faces;
+GEO::Mesh sf_mesh;
+std::vector<int> input_tags;
+
+bool ok = floatTetWild::MeshIO::load_mesh(
+    "input.off", input_vertices, input_faces, sf_mesh, input_tags
+);
+```
+
+The `sf_mesh` output is what you pass to `tetrahedralization()`.
+
+---
+
+## Writing Output
+
+Use `MeshIO::write_mesh()` to write the internal `Mesh` object to `.msh` (binary by default) or `.mesh`:
+
+```cpp
+#include <floattetwild/MeshIO.hpp>
+
+// After tetrahedralization, if you have the internal Mesh object:
+floatTetWild::MeshIO::write_mesh("output.msh", mesh, /*is_surface=*/false);
+
+// To write a surface-only mesh (for mesh repair use case):
+Eigen::MatrixXd V_sf;
+Eigen::MatrixXi F_sf;
+floatTetWild::get_surface(mesh, V_sf, F_sf);
+igl::write_triangle_mesh("surface.obj", V_sf, F_sf);
+```
+
+For reading/writing `.msh` files independently of the algorithm, use `PyMesh::MshLoader` and `PyMesh::MshSaver` from `src/external/`.
+
+---
+
+## Parameters Reference
+
+See [`data_structures.md`](data_structures.md) for the full `Parameters` field reference, and the CLI flags in the `README.md` for the command-line equivalents of each parameter.
+
+Key defaults:
+
+| Parameter | Default | Effect |
+|---|---|---|
+| `eps_rel` | 1e-3 | Envelope size as fraction of bbox diagonal |
+| `ideal_edge_length_rel` | 0.05 | Target edge length as fraction of bbox diagonal |
+| `ideal_edge_length_abs` | 0 | Absolute target edge length (overrides relative) |
+| `stop_energy` | 10 | Stop when max AMIPS < this |
+| `max_its` | 80 | Max optimization iterations |
+| `smooth_open_boundary` | false | Smooth open boundary faces |
+| `manifold_surface` | false | Guarantee manifold output surface |
+| `disable_filtering` | false | Keep all tets (no exterior removal) |
+| `use_floodfill` | false | Use flood-fill instead of winding number |
+| `coarsen` | false | Aggressively coarsen output |
+
+---
+
+## Geogram Initialization
+
+`GEO::initialize()` must be called exactly once before using any geogram functionality (including fTetWild). On Linux/macOS, also set:
+
+```cpp
+#ifndef WIN32
+    setenv("GEO_NO_SIGNAL_HANDLER", "1", 1);
+#endif
+GEO::initialize();
+```
+
+To suppress geogram's console output, redirect its logger (as done in `src/main.cpp`):
+
+```cpp
+GEO::Logger* geo_logger = GEO::Logger::instance();
+geo_logger->unregister_all_clients();
+// optionally re-register a custom client that forwards to spdlog
+geo_logger->set_pretty(false);
+```
+
+---
+
+## Thread Safety
+
+The `Statistics` singleton (`src/Statistics.h`) is thread-safe via a mutex. The `Mesh` object and all algorithm functions are **not** thread-safe — do not call `tetrahedralization()` concurrently on the same `Mesh`. Concurrent calls on independent `Mesh` objects are safe.
+
+TBB parallelism is used internally during preprocessing and vertex smoothing. The number of threads is controlled by `params.num_threads` (default: hardware concurrency).

--- a/doc/mesh_improvement.md
+++ b/doc/mesh_improvement.md
@@ -26,7 +26,11 @@ where J is the Jacobian of the affine map from a regular reference tetrahedron t
 - Scale-invariant: same quality for any scaling of T
 - Differentiable: enables gradient-based vertex smoothing
 
-**Numerical instability fix**: When AMIPS(T) > 10⁸, standard floating-point evaluation is non-deterministic (different vertex permutations give wildly different values — up to 4 orders of magnitude difference). The implementation detects this via `is_energy_unstable()` and falls back to rational arithmetic for the intermediate cubed-energy computation, then takes the cubic root. This prevents unnecessary over-refinement.
+**Numerical instability fix**: When AMIPS(T) > 10⁸, standard floating-point evaluation is non-deterministic (different vertex permutations give wildly different values — up to 4 orders of magnitude difference). The implementation detects this via `is_energy_unstable()` and falls back to higher-precision arithmetic for the intermediate cubed-energy computation, then takes the cubic root. This prevents unnecessary over-refinement.
+
+Two backends are available for the fallback, selected at compile time via `FLOAT_TETWILD_USE_GMP`:
+- **Default (OFF)**: `long double` (80-bit extended precision on x86/x86_64). No extra dependency.
+- **GMP (ON)**: `triwild::Rational` backed by GMP arbitrary-precision rationals. Exact on all platforms, requires `libgmp-dev`.
 
 ---
 

--- a/doc/mesh_improvement.md
+++ b/doc/mesh_improvement.md
@@ -1,0 +1,113 @@
+# Phase 3: Mesh Improvement
+
+**Source**: `src/MeshImprovement.h/.cpp`, `src/EdgeSplitting.h/.cpp`, `src/EdgeCollapsing.h/.cpp`, `src/EdgeSwapping.h/.cpp`, `src/VertexSmoothing.h/.cpp`, `src/LocalOperations.h/.cpp`  
+**Entry point**: `floatTetWild::optimization(input_vertices, input_faces, input_tags, is_face_inserted, mesh, tree, ops)`
+
+---
+
+## Purpose
+
+After triangle insertion, the mesh contains many poorly-shaped elements — especially around inserted faces where the tet-subdivision table cuts tets into small sub-tets. Phase 3 iteratively improves element quality by applying four types of local topology/geometry operations while maintaining the two validity invariants (no inverted tets, tracked surface within ε-envelope).
+
+---
+
+## Quality Metric: Conformal AMIPS Energy
+
+Every operation uses the **conformal AMIPS 3D energy** to measure element quality:
+
+```
+AMIPS(T) = tr(Jᵀ J) / det(J)^(2/3)
+```
+
+where J is the Jacobian of the affine map from a regular reference tetrahedron to T.
+
+- Minimum value: **3** (achieved by a regular tetrahedron)
+- Range: [3, +∞)
+- Scale-invariant: same quality for any scaling of T
+- Differentiable: enables gradient-based vertex smoothing
+
+**Numerical instability fix**: When AMIPS(T) > 10⁸, standard floating-point evaluation is non-deterministic (different vertex permutations give wildly different values — up to 4 orders of magnitude difference). The implementation detects this via `is_energy_unstable()` and falls back to rational arithmetic for the intermediate cubed-energy computation, then takes the cubic root. This prevents unnecessary over-refinement.
+
+---
+
+## The Four Local Operations
+
+### 1. Edge Splitting (`src/EdgeSplitting.cpp`)
+
+Splits an edge [v₀, v₁] by inserting a new midpoint vertex. All incident tetrahedra are replaced by two new tets each.
+
+- **Triggered when**: edge length > `split_threshold` = 4/3 × ℓ
+- **Accepted when**: no new tet is inverted, no new tet exceeds a quality threshold, and if any split face was tracked surface, all new tracked faces remain within ε-envelope
+- **Priority queue**: edges sorted by length (longest first)
+
+### 2. Edge Collapsing (`src/EdgeCollapsing.cpp`)
+
+Collapses an edge [v₀, v₁] by merging one vertex onto the other (or to a new midpoint). All tets sharing the collapsed edge are removed.
+
+- **Triggered when**: edge length < `collapse_threshold` = 4/5 × ℓ
+- **Rejection conditions**: collapse creates inverted tets, violates envelope, or removes a surface feature
+- **Priority queue**: edges sorted by length (shortest first)
+- **Surface vertices**: if v₀ is on the tracked surface, it may only move to positions that keep the surface within ε
+
+### 3. Edge Swapping (`src/EdgeSwapping.cpp`)
+
+Replaces an edge with a better-placed edge in the same "diamond" of surrounding tets (2→3 flip, 3→2 flip, or similar). This changes topology without moving vertex positions.
+
+- **Triggered when**: swapping would reduce the maximum AMIPS energy among affected tets
+- **Exact predicates** verify that no element is inverted after the swap
+- The full set of swaps is performed round-robin until no further improvement is possible
+
+### 4. Vertex Smoothing (`src/VertexSmoothing.cpp`)
+
+Moves each vertex to a new position that minimizes the maximum AMIPS energy of its incident tets. This is a local unconstrained optimization using Newton's method on the AMIPS energy.
+
+- **Parallelized** using a graph-coloring scheme: vertices are partitioned into independent sets (no two vertices in the same set share an incident tet) using `Mesh::one_ring_vertex_sets()`. Each set is processed in parallel with TBB, then the next set serially.
+- **Surface vertices** are constrained: only moves that keep all tracked faces within ε are accepted.
+- **Boundary vertices** (on open boundaries) are projected back to the boundary after smoothing.
+
+---
+
+## Optimization Loop
+
+```
+for iter = 1 to max_its:
+    apply edge_splitting
+    apply edge_collapsing
+    apply edge_swapping
+    apply vertex_smoothing
+
+    if iter % 3 == 0:
+        retry_failed_triangle_insertions()
+
+    max_e = get_max_energy()
+    if max_e < stop_energy:
+        break
+
+    update_scaling_field(mesh, max_e)  # if sizing field enabled
+```
+
+The `ops` parameter to `optimization()` is a 4-bit mask `{split, collapse, swap, smooth}` that enables/disables individual operations (used internally for debugging and for coarsening mode).
+
+---
+
+## Scaling Field
+
+If a background sizing mesh is provided (`--bg-mesh`), the `sizing_scalar` of each vertex is interpolated from the background mesh's vertex scalar field. This scalar multiplicatively adjusts the split/collapse thresholds at each vertex, enabling adaptive mesh density.
+
+If coarsening mode is enabled (`--coarsen`), the algorithm applies `apply_coarsening()` after the main optimization loop, aggressively collapsing edges to reduce the mesh to its coarsest valid form.
+
+---
+
+## Acceptance Criteria for All Operations
+
+Every proposed local operation is rolled back if:
+1. Any resulting tetrahedron is inverted (checked with exact orient3d predicates).
+2. Any resulting tetrahedron has AMIPS energy worse than the element it replaces (for smoothing, the condition is the neighborhood's max energy).
+3. Any tracked surface face is moved outside the ε-envelope after the operation.
+4. Any bounding-box face would be disturbed.
+
+---
+
+## Empty Slot Management
+
+The mesh uses lazy deletion: removed vertices and tets are flagged with `is_removed = true` rather than actually erased. Periodically (in `cleanup_empty_slots()`), when the fraction of removed slots exceeds a threshold (default 70%), the vectors are compacted to reclaim memory. The empty-slot cursors `t_empty_start` and `v_empty_start` are reset after each compaction via `reset_t_empty_start()` / `reset_v_empty_start()`.

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,0 +1,98 @@
+# fTetWild Algorithm Overview
+
+fTetWild (Fast Tetrahedral Meshing in the Wild) converts an arbitrary triangle soup into a high-quality tetrahedral mesh. It requires no assumption about input quality: self-intersections, gaps, duplicate vertices, degenerate faces and non-manifold regions are all handled automatically.
+
+**Reference**: Yixin Hu, Teseo Schneider, Bolun Wang, Denis Zorin, Daniele Panozzo. *Fast Tetrahedral Meshing in the Wild*. ACM Transactions on Graphics (SIGGRAPH 2020).
+
+---
+
+## Core Idea
+
+The algorithm operates within an ε-envelope: a tube of radius ε around the input surface. The output mesh boundary is guaranteed to lie inside this envelope, so imperfections smaller than ε are resolved automatically. The default ε is 10⁻³ × d, where d is the diagonal of the bounding box.
+
+Unlike TetWild (its predecessor), fTetWild works entirely in **floating-point arithmetic**. It maintains an inversion-free tetrahedral mesh at every algorithmic step, eliminating the expensive exact rational arithmetic that made TetWild slow.
+
+---
+
+## The Four Phases
+
+```
+Input surface mesh
+       │
+       ▼
+┌─────────────────────┐
+│ 1. Preprocessing    │  Simplify input, merge near-duplicate vertices,
+│    (Simplification) │  collapse short edges while staying in ε-envelope.
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│ 2. Background mesh  │  Delaunay tetrahedralization on preprocessed
+│  + Triangle Insert. │  points + grid points. Then insert input
+│    (incremental)    │  triangles one at a time using a table-based
+│                     │  tet-subdivision scheme (snapping + cut).
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│ 3. Mesh Improvement │  Iterative local operations (split, collapse,
+│    (optimization)   │  swap, smooth) minimizing conformal AMIPS
+│                     │  energy. Retries failed insertions every 3
+│                     │  iterations.
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│ 4. Filtering        │  Remove tetrahedra outside the surface using
+│    (winding number  │  winding number or flood-fill. Boolean CSG
+│     or flood-fill)  │  operations are applied here.
+└────────┬────────────┘
+         │
+         ▼
+Output tetrahedral mesh (.msh / .mesh)
+```
+
+---
+
+## Key Properties
+
+| Property | Value |
+|---|---|
+| Always produces valid output | Yes (inversion-free, floating-point) |
+| Tolerates imperfect input | Yes (self-intersections, gaps, non-manifold) |
+| Envelope guarantee | Boundary within ε of input |
+| Default ε | 10⁻³ × bbox diagonal |
+| Default target edge length ℓ | bbox diagonal / 20 |
+| Mesh quality metric | Conformal AMIPS energy ∈ [3, +∞), optimal = 3 |
+| Default stop energy | 10 |
+| Max optimization iterations | 80 |
+| Parallelism | TBB (preprocessing + vertex smoothing) |
+
+---
+
+## Comparison With TetWild
+
+| | TetWild | fTetWild |
+|---|---|---|
+| Arithmetic | Rational (exact) | Floating-point |
+| Triangle insertion | BSP (all at once) | Incremental (one at a time) |
+| Valid FP output guaranteed | No | Yes |
+| Speed (avg on Thingi10k) | 360 s | 49.8 s (with parallelism) |
+| Success rate on 10k models | 99.89% | 99.97% |
+
+---
+
+## Source Layout
+
+| File(s) | Phase |
+|---|---|
+| `src/Simplification.h/.cpp` | Phase 1: preprocessing |
+| `src/FloatTetDelaunay.h/.cpp` | Phase 2: background mesh generation |
+| `src/TriangleInsertion.h/.cpp`, `src/CutMesh.h/.cpp` | Phase 2: triangle insertion |
+| `src/MeshImprovement.h/.cpp` | Phases 3 & 4: optimization + filtering |
+| `src/EdgeSplitting`, `EdgeCollapsing`, `EdgeSwapping`, `VertexSmoothing` | Phase 3: local operations |
+| `src/LocalOperations.h/.cpp` | Shared geometry helpers (energy, predicates) |
+| `src/AABBWrapper.h/.cpp` | Envelope queries (wraps geogram AABB) |
+| `src/FloatTetwild.h/.cpp` | Library entry point |
+| `src/main.cpp` | CLI entry point |
+| `src/Mesh.hpp`, `src/Parameters.h`, `src/Types.hpp` | Data structures |

--- a/doc/preprocessing.md
+++ b/doc/preprocessing.md
@@ -1,0 +1,71 @@
+# Phase 1: Input Preprocessing
+
+**Source**: `src/Simplification.h/.cpp`  
+**Entry point**: `floatTetWild::simplify(input_vertices, input_faces, input_tags, tree, params, skip_simplify)`
+
+---
+
+## Purpose
+
+The raw input triangle soup often contains near-duplicate vertices, degenerate or nearly-degenerate triangles, and small topological noise. Preprocessing simplifies the input while keeping the result inside the **ε-prep envelope** (= 0.8 × ε by default), leaving room for the insertion snapping tolerance and for surface vertices to move during mesh improvement.
+
+The preprocessing envelope is intentionally smaller than the final ε (80% of ε) for two reasons:
+1. It preserves room for the snapping tolerance δ used during triangle insertion.
+2. It prevents surface vertices from being too close to the envelope boundary, giving them freedom to move during mesh quality optimization.
+
+---
+
+## Steps
+
+### 1. Remove Duplicate Vertices (`remove_duplicates`)
+
+Merge input vertices whose distance is below `SCALAR_ZERO` (ε_zero = 1e-8). After merging, degenerate faces (with two identical vertex indices) are discarded.
+
+### 2. Edge Collapsing (`collapsing`)
+
+Iteratively collapse short edges of the input surface mesh, subject to two conditions:
+
+1. **Manifold constraint**: the edge must be a manifold edge (at most two incident triangles), and all vertex-adjacent edges must also be manifold. This prevents destroying topological structure.
+2. **Envelope constraint**: collapsing the edge must not move any triangle outside the `eps_simplification` envelope (verified using the AABB tree).
+
+This step is **parallelized** using a 2-coloring strategy (see Parallel Coloring below).
+
+### 3. Edge Swapping (`swapping`)
+
+Swap edges to improve the triangulation of the input surface. Only swaps that keep all faces inside the envelope are accepted.
+
+### 4. Flattening (`flattening`)
+
+Merge nearly-coplanar vertices that are very close to each other but survived the collapsing step.
+
+---
+
+## Parallel Coloring for Edge Collapsing
+
+The parallelization strategy marks a safe independent set of edges in each pass:
+
+1. Color all input triangles **white**.
+2. Mark an edge as **parallel-independent** if _all_ vertex-adjacent triangles are white. Color those triangles **black**.
+3. All marked parallel-independent edges are collapsed simultaneously using TBB.
+4. Iterate until fewer than 0.01% of original vertices are removed in a pass.
+
+This guarantees no two simultaneously collapsed edges share a vertex or adjacent triangle, making the parallel execution safe.
+
+---
+
+## Envelope Checking
+
+The `AABBWrapper` is used to sample each modified triangle and check whether the samples lie within the AABB tree's proximity threshold. The AABB tree is built from the original input surface `sf_mesh` and queried using `MeshFacetsAABBWithEps::is_in_envelope()`.
+
+When `FLOAT_TETWILD_WITH_EXACT_ENVELOPE` is enabled (compile flag), the `FastEnvelope` library replaces the sampling-based check with an exact envelope containment test.
+
+---
+
+## Output
+
+After preprocessing:
+- `input_vertices` — reduced and deduplicated 3D vertex positions
+- `input_faces` — reduced triangle index list
+- `input_tags` — per-face integer tags (used for boolean/CSG operations)
+
+These are passed directly to the Delaunay tetrahedralization and triangle insertion stages.

--- a/doc/triangle_insertion.md
+++ b/doc/triangle_insertion.md
@@ -1,0 +1,134 @@
+# Phase 2: Incremental Triangle Insertion
+
+**Sources**: `src/FloatTetDelaunay.h/.cpp`, `src/TriangleInsertion.h/.cpp`, `src/CutMesh.h/.cpp`, `src/auto_table.hpp/.cpp`  
+**Entry points**:
+- `FloatTetDelaunay::tetrahedralize(...)` — builds the initial background mesh
+- `insert_triangles(...)` — performs the incremental insertion loop
+
+---
+
+## 2a. Background Mesh Generation
+
+Before any triangle insertion, fTetWild creates an initial tetrahedral mesh that fills the input's expanded bounding box.
+
+**Steps**:
+1. Expand the bounding box by 2ε in all directions (so surface points have room to move).
+2. Add 8 bounding-box corner vertices.
+3. Add additional grid points at spacing ℓ/20 (where ℓ = `ideal_edge_length`), skipping any point within ε of an input face. These uniform points improve the initial element quality by filling the space evenly.
+4. Run Geogram's Delaunay 3D tetrahedralization (`GEO::Delaunay_3d`) on the combined point set.
+5. Populate the `Mesh` structure and initialize adjacency (`opp_t_ids`).
+
+The result is a valid, inversion-free tetrahedral mesh that does not yet conform to any input triangles.
+
+---
+
+## 2b. Incremental Triangle Insertion
+
+### Overview
+
+Each input triangle T is inserted one at a time into the current `Mesh M`. A failed insertion (one that would create an inverted or degenerate element) is rolled back, and the triangle is deferred for later retry after the mesh quality has improved.
+
+Insertion of a single triangle T has three main stages:
+
+```
+┌──────────────────────┐
+│ Find cut tetrahedra  │  Identify TI = {tets that T cuts}
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│ Snapping             │  Move mesh vertices within δ of T's plane P
+└──────────┬───────────┘  onto P (if doing so doesn't invert any tet)
+           │
+           ▼
+┌──────────────────────┐
+│ Table-based          │  Subdivide all tets in TI using the
+│ tet-subdivision      │  precomputed tet-subdivision table
+└──────────────────────┘
+```
+
+---
+
+### Finding Cut Tetrahedra (TI)
+
+A triangle T *cuts* a tetrahedron T if:
+- T is completely contained inside T, **or**
+- T cuts through at least one face of T (the intersection contains interior points of both T and the face).
+
+Pure edge/vertex touches that contain no interior points are excluded. Exact predicates (Shewchuk) are used to determine containment and face-triangle intersection.
+
+The set TI is grown iteratively: any tet adjacent to a vertex that was snapped and lies in T's cutting region is added.
+
+---
+
+### Snapping
+
+Snapping reduces insertion failures by moving mesh vertices that are within a distance δ of T's plane P onto P itself, as long as this does not create inverted tetrahedra:
+
+**δ values**:
+- First insertion pass: δ = max(ε_zero, 10⁻³ × ε) — larger, more aggressive
+- Subsequent passes: δ = ε_zero = 1e-8 — minimal
+
+**Snapping algorithm (4 steps)**:
+1. Find all vertices of TI within distance δ of P → set Vδ.
+2. Move each vertex in Vδ to its closest point on P, if no element would be inverted. If a vertex cannot be moved to P, instead some vertices of the "cover face" F are snapped to the vertex.
+3. For each vertex in Vδ, expand TI with any neighbor tets that (a) are cut by P and (b) have a face that projects over T.
+4. Repeat until no new tets are added.
+
+If moving a boundary vertex of the cover F would invalidate the cover (by changing F's boundary), TI is first expanded to include the 1-ring neighborhood until the affected vertex becomes an interior vertex of F.
+
+---
+
+### Table-Based Tet Subdivision (`src/auto_table.hpp/.cpp`)
+
+After snapping, every tet T in TI is subdivided according to which of its 6 edges are cut by P. The precomputed **tet-subdivision table** maps an (primary_index, secondary_index) pair to a list of sub-tets.
+
+**Primary index (I)**: 6-bit binary string indicating which edges are cut. 64 combinations exist, of which 23 are geometrically impossible (e.g. 5 or 6 cut edges). The 41 realizable configurations form 7 symmetry classes:
+
+| Class | Description |
+|---|---|
+| (1) | No cut edges |
+| (2) | 1 edge cut |
+| (3) | 2 adjacent edges cut (sharing a vertex) |
+| (4) | 2 opposite edges cut |
+| (5) | 3 edges forming a path |
+| (6) | 3 edges on one face (triangle of cuts) |
+| (7) | 4 edges cut |
+
+Classes (4) and (6) can only occur on neighboring tets of TI (not on tets that T directly cuts through).
+
+**Secondary index (II)**: When two edges on a face are cut, two triangulations of that face exist. The secondary index selects one. The choice is deterministic and unique: for face [v₀, v₁, v₂] with intersection points p₁ and p₂, use the triangulation containing edge [p₂, v₁] if `label(v₁) > label(v₂)`, otherwise use [p₁, v₂]. This rule is based solely on global vertex ordering, ensuring consistency across adjacent tets without any look-ahead.
+
+All generated sub-tetrahedra are checked for volume > ε³_zero. If any sub-tet is degenerate, the entire insertion is rolled back.
+
+---
+
+### Open-Boundary Edge Preservation
+
+After a triangle is inserted, shared edges between non-coplanar adjacent triangles are naturally preserved (the plane of the second triangle will cut through the cover of the first). However, **open-boundary edges** (edges with only one incident non-coplanar triangle) require explicit handling.
+
+For each open-boundary edge e of triangle T:
+1. Project e and the cover F of T onto the best-fitting plane P' of F's vertices.
+2. Compute the intersections of e's projection with the face projections in 2D.
+3. Lift the 2D intersection points back to 3D on the faces of F.
+4. Further subdivide the affected neighboring tetrahedra using the same table-based scheme.
+
+If this fails numerically, the triangle insertion is rolled back and deferred.
+
+---
+
+### Retry Loop
+
+Insertion is attempted for all input triangles sequentially. Any triangle that cannot be inserted (due to near-degenerate elements or numerical failures) is added to a "failed" list. During mesh improvement (Phase 3), every 3 optimization iterations the insertion of failed triangles is reattempted on the improved mesh. This continues until all triangles are inserted or the optimization terminates.
+
+In practice on the Thingi10k dataset of 10,000 models, all triangles are always successfully inserted.
+
+---
+
+### Validity Invariant
+
+At every point during triangle insertion (and throughout the entire algorithm), the mesh is maintained in a **valid** state:
+1. Every tetrahedron has positive volume (checked with exact Shewchuk predicates).
+2. Every successfully inserted triangle (the *tracked surface*) lies within ε of the input.
+
+Any operation that would violate either condition is immediately rolled back.

--- a/src/external/Rational.h
+++ b/src/external/Rational.h
@@ -9,167 +9,141 @@
 #ifndef TRIWILD_RATIONAL_H
 #define TRIWILD_RATIONAL_H
 
+#ifdef FLOAT_TETWILD_USE_GMP
+
+// ---------------------------------------------------------------------------
+// GMP-backed exact rational arithmetic
+// ---------------------------------------------------------------------------
 #include <gmp.h>
 #include <iostream>
 
 namespace triwild {
 
-    class Rational {//https://cs.nyu.edu/acsys/cvc3/releases/1.5/doc/rational-gmp_8cpp-source.html
-    public:
-        mpq_t value;
-        void canonicalize() {
-            mpq_canonicalize(value);
-        }
-        int get_sign() {
-            return mpq_sgn(value);
-        }
+class Rational {
+public:
+    mpq_t value;
 
-        Rational() {
-            mpq_init(value);
-            mpq_set_d(value, 0);
-        }
+    void canonicalize() { mpq_canonicalize(value); }
+    int  get_sign()     { return mpq_sgn(value); }
 
-        Rational(double d) {
-            mpq_init(value);
-            mpq_set_d(value, d);
-//            canonicalize();
-        }
+    Rational()               { mpq_init(value); mpq_set_d(value, 0); }
+    Rational(double d)       { mpq_init(value); mpq_set_d(value, d); }
+    Rational(const mpq_t& v) { mpq_init(value); mpq_set(value, v); }
+    Rational(const Rational& o) { mpq_init(value); mpq_set(value, o.value); }
 
-        Rational(const mpq_t &v_) {
-            mpq_init(value);
-            mpq_set(value, v_);
-//            canonicalize();
-        }
+    ~Rational() { mpq_clear(value); }
 
-        Rational(const Rational &other) {
-            mpq_init(value);
-            mpq_set(value, other.value);
-        }
+    Rational& operator=(const Rational& x) {
+        if (this != &x) mpq_set(value, x.value);
+        return *this;
+    }
+    Rational& operator=(double x) { mpq_set_d(value, x); return *this; }
 
-        ~Rational() {
-            mpq_clear(value);
-        }
+    friend Rational operator-(const Rational& x)
+        { Rational r; mpq_neg(r.value, x.value); return r; }
+    friend Rational operator+(const Rational& x, const Rational& y)
+        { Rational r; mpq_add(r.value, x.value, y.value); return r; }
+    friend Rational operator-(const Rational& x, const Rational& y)
+        { Rational r; mpq_sub(r.value, x.value, y.value); return r; }
+    friend Rational operator*(const Rational& x, const Rational& y)
+        { Rational r; mpq_mul(r.value, x.value, y.value); return r; }
+    friend Rational operator/(const Rational& x, const Rational& y)
+        { Rational r; mpq_div(r.value, x.value, y.value); return r; }
 
-//        //+, - another point
-//        Rational operator+(const Rational &r) const {
-//            Rational r_out;
-//            mpq_add(r_out.value, value, r.value);
-//            return r_out;
-//        }
+    friend Rational pow(const Rational& x, int p) {
+        Rational r = x;
+        for (int i = 1; i < std::abs(p); i++) r = r * x;
+        if (p < 0) return Rational(1.0) / r;
+        return r;
+    }
+
+    friend bool operator< (const Rational& r, const Rational& s) { return mpq_cmp(r.value, s.value) <  0; }
+    friend bool operator> (const Rational& r, const Rational& s) { return mpq_cmp(r.value, s.value) >  0; }
+    friend bool operator<=(const Rational& r, const Rational& s) { return mpq_cmp(r.value, s.value) <= 0; }
+    friend bool operator>=(const Rational& r, const Rational& s) { return mpq_cmp(r.value, s.value) >= 0; }
+    friend bool operator==(const Rational& r, const Rational& s) { return  mpq_equal(r.value, s.value); }
+    friend bool operator!=(const Rational& r, const Rational& s) { return !mpq_equal(r.value, s.value); }
+
+    double to_double() { return mpq_get_d(value); }
+
+    friend std::ostream& operator<<(std::ostream& os, const Rational& r) {
+        os << mpq_get_d(r.value); return os;
+    }
+};
+
+} // namespace triwild
+
+#else // FLOAT_TETWILD_USE_GMP
+
+// ---------------------------------------------------------------------------
+// Fallback: long double arithmetic
 //
-//        Rational operator-(const Rational &r) const {
-//            Rational r_out;
-//            mpq_sub(r_out.value, value, r.value);
-//            return r_out;
-//        }
-//
-//        //*, / double/rational
-//        Rational operator*(const Rational &r) const {
-//            Rational r_out;
-//            mpq_mul(r_out.value, value, r.value);
-//            return r_out;
-//        }
-//
-//        Rational operator/(const Rational &r) const {
-//            Rational r_out;
-//            mpq_div(r_out.value, value, r.value);
-//            return r_out;
-//        }
-//
-//        //=
-//        void operator=(const Rational &r) {
-//            mpq_set(value, r.value);
-//        }
+// Uses 80-bit extended precision (x86/x86_64 with GCC/Clang) which is
+// sufficient to stabilise the AMIPS energy evaluation for elements with
+// energy up to ~10^8 without requiring GMP.  The same public API as the
+// GMP implementation is preserved so the rest of the codebase is unchanged.
+// ---------------------------------------------------------------------------
+#include <cmath>
+#include <iostream>
 
+namespace triwild {
 
-        friend Rational operator-(const Rational& x) {
-            Rational r_out;
-            mpq_neg(r_out.value, x.value);
-            return r_out;
-        }
+class Rational {
+public:
+    long double value = 0.0L;
 
-        friend Rational operator+(const Rational& x, const Rational& y) {
-            Rational r_out;
-            mpq_add(r_out.value, x.value, y.value);
-            return r_out;
-        }
+    void canonicalize() {}
+    int  get_sign() const {
+        if (value > 0.0L) return  1;
+        if (value < 0.0L) return -1;
+        return 0;
+    }
 
-        friend Rational operator-(const Rational& x, const Rational& y) {
-            Rational r_out;
-            mpq_sub(r_out.value, x.value, y.value);
-            return r_out;
-        }
+    Rational() = default;
+    Rational(double d)  : value(static_cast<long double>(d)) {}
+    Rational(int i)     : value(static_cast<long double>(i)) {}
+    Rational(long long i) : value(static_cast<long double>(i)) {}
+    Rational(const Rational&) = default;
+    ~Rational() = default;
 
-        friend Rational operator*(const Rational& x, const Rational& y) {
-            Rational r_out;
-            mpq_mul(r_out.value, x.value, y.value);
-            return r_out;
-        }
+    Rational& operator=(const Rational&) = default;
+    Rational& operator=(double x) { value = static_cast<long double>(x); return *this; }
 
-        friend Rational operator/(const Rational& x, const Rational& y) {
-            Rational r_out;
-            mpq_div(r_out.value, x.value, y.value);
-            return r_out;
-        }
+    friend Rational operator-(const Rational& x)
+        { Rational r; r.value = -x.value; return r; }
+    friend Rational operator+(const Rational& x, const Rational& y)
+        { Rational r; r.value = x.value + y.value; return r; }
+    friend Rational operator-(const Rational& x, const Rational& y)
+        { Rational r; r.value = x.value - y.value; return r; }
+    friend Rational operator*(const Rational& x, const Rational& y)
+        { Rational r; r.value = x.value * y.value; return r; }
+    friend Rational operator/(const Rational& x, const Rational& y)
+        { Rational r; r.value = x.value / y.value; return r; }
 
-        friend Rational pow(const Rational& x, int p) {
-            Rational r_out = x;
-            for (int i = 1; i < std::abs(p); i++) {
-                r_out = r_out * x;
-            }
-            if (p < 0)
-                return 1 / r_out;
-            return r_out;
-        }
+    friend Rational pow(const Rational& x, int p) {
+        if (p == 0) return Rational(1.0);
+        Rational r = x;
+        for (int i = 1; i < std::abs(p); i++) r = r * x;
+        if (p < 0) { Rational one(1.0); return one / r; }
+        return r;
+    }
 
-        Rational& operator=(const Rational& x) {
-            if (this == &x) return *this;
-            mpq_set(value, x.value);
-            return *this;
-        }
+    friend bool operator< (const Rational& r, const Rational& s) { return r.value <  s.value; }
+    friend bool operator> (const Rational& r, const Rational& s) { return r.value >  s.value; }
+    friend bool operator<=(const Rational& r, const Rational& s) { return r.value <= s.value; }
+    friend bool operator>=(const Rational& r, const Rational& s) { return r.value >= s.value; }
+    friend bool operator==(const Rational& r, const Rational& s) { return r.value == s.value; }
+    friend bool operator!=(const Rational& r, const Rational& s) { return r.value != s.value; }
 
-        Rational& operator=(const double x) {
-            mpq_set_d(value, x);
-//            canonicalize();
-            return *this;
-        }
+    double to_double() const { return static_cast<double>(value); }
 
-        //> < ==
-        friend bool operator<(const Rational &r, const Rational &r1) {
-            return mpq_cmp(r.value, r1.value) < 0;
-        }
+    friend std::ostream& operator<<(std::ostream& os, const Rational& r) {
+        os << r.to_double(); return os;
+    }
+};
 
-        friend bool operator>(const Rational &r, const Rational &r1) {
-            return mpq_cmp(r.value, r1.value) > 0;
-        }
+} // namespace triwild
 
-        friend bool operator<=(const Rational &r, const Rational &r1) {
-            return mpq_cmp(r.value, r1.value) <= 0;
-        }
+#endif // FLOAT_TETWILD_USE_GMP
 
-        friend bool operator>=(const Rational &r, const Rational &r1) {
-            return mpq_cmp(r.value, r1.value) >= 0;
-        }
-
-        friend bool operator==(const Rational &r, const Rational &r1) {
-            return mpq_equal(r.value, r1.value);
-        }
-
-        friend bool operator!=(const Rational &r, const Rational &r1) {
-            return !mpq_equal(r.value, r1.value);
-        }
-
-        //to double
-        double to_double() {
-            return mpq_get_d(value);
-        }
-
-        //<<
-        friend std::ostream &operator<<(std::ostream &os, const Rational &r) {
-            os << mpq_get_d(r.value);
-            return os;
-        }
-    };
-}
-
-#endif //TRIWILD_RATIONAL_H
+#endif // TRIWILD_RATIONAL_H


### PR DESCRIPTION
### Summary

GMP (GNU Multiple Precision) was previously a hard build requirement that caused cmake to abort when the library was not installed. This PR makes GMP opt-in and ships a full documentation set and a convenience configure script.

---

### Changes

#### GMP is now optional (`FLOAT_TETWILD_USE_GMP`)

- **CMakeLists.txt** — added a new CMake option `FLOAT_TETWILD_USE_GMP` (default `OFF`). When disabled, `find_package(GMPfTetWild)` is skipped entirely and GMP headers/libraries are never linked. When enabled, the existing GMP path is used and the preprocessor macro `FLOAT_TETWILD_USE_GMP` is propagated to the library.
- **Rational.h** — the `Rational` class is now conditionally compiled:
  - With `-DFLOAT_TETWILD_USE_GMP=ON`: full GMP-backed `mpq_t` exact rational arithmetic (previous behaviour).
  - Without (default): a lightweight `long double` fallback implementation is used for AMIPS energy stabilisation, removing the hard GMP dependency for the common case.

#### New configure script (configure.sh)

A self-contained Bash helper that wraps cmake with a structured argument parser. Features include:
- All fTetWild feature flags exposed as named options (`--with-gmp`, `--no-tbb`, `--exact-envelope`, `--use-float`, …).
- Compiler, sanitizer (ASan / MSan / TSan / UBSan), and dependency-path overrides.
- Auto-detects Ninja vs. Unix Makefiles; prints a human-readable configuration summary before running cmake.
- `--dry-run` mode prints the assembled cmake command without executing it.
- `--offline` sets `FETCHCONTENT_UPDATES_DISCONNECTED=ON` for air-gapped builds.

#### Documentation (doc)

Nine new Markdown files documenting the algorithm and codebase:

| File | Content |
|---|---|
| index.md | Entry point and navigation |
| overview.md | High-level algorithm overview and pipeline |
| preprocessing.md | Input surface preparation |
| triangle_insertion.md | Triangle insertion into the tetrahedral mesh |
| mesh_improvement.md | Local mesh improvement operations |
| data_structures.md | Core data-structure reference |
| filtering_and_booleans.md | Inside/outside filtering and CSG booleans |
| envelope_and_aabb.md | Envelope and AABB wrapper details |
| dependencies.md | Third-party dependencies overview |

**README.md** was updated to reference the new docs, clarify that GMP is optional, and describe the `--with-gmp` configure flag.

---

### Migration / upgrade notes

- **Existing users who rely on GMP exact arithmetic**: pass `-DFLOAT_TETWILD_USE_GMP=ON` to cmake (or `--with-gmp` to `configure.sh`) — behaviour is identical to before.
- **New users / CI without libgmp-dev**: no change needed; the build works out of the box with the `long double` fallback.